### PR TITLE
Fixed issue with init not creating the correct directory for the .con…

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -167,7 +167,7 @@ License:
 		os.Exit(1)
 	}
 
-	err = os.MkdirAll(config.CONFIG.ConfigDir, os.ModePerm)
+	err = os.MkdirAll(config.ProfileDir(), os.ModePerm)
 	if err != nil {
 		fmt.Println("ERROR:", err)
 		os.Exit(1)


### PR DESCRIPTION
…fig/dfm/profiles path.

Changed line 170 in cli.go to make MkdirAll to take the config.Profile() fixing the issue of the directories not correctly being made.