### PR TITLE
Feature: use last matching mapping for linking

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 dfm = {editable = true, path = "."}
+GitPython = "*"
 
 [dev-packages]
 black = "*"

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     install_requires=[
         "docopt",
         "PyYAML>=3.13",
+        "GitPython"
     ],
     entry_points={"console_scripts": ["dfm = dfm.cli:main"]},
     classifiers=[

--- a/src/dfm/cli/clean_cmd.py
+++ b/src/dfm/cli/clean_cmd.py
@@ -14,7 +14,7 @@ import textwrap
 from yaspin import yaspin
 
 from dfm.cli.utils import inject_profile
-from dfm.config import xdg_dir
+from dfm.config import home_dir, xdg_dir
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ def clean_links(directory, profile_dir):
 @inject_profile
 def run(_args, profile):
     """Run the clean subcommand."""
-    home = os.getenv("HOME")
+    home = home_dir()
     xdg = xdg_dir()
     if home:
         clean_links(home, profile.link_manager.where)

--- a/src/dfm/config.py
+++ b/src/dfm/config.py
@@ -1,13 +1,19 @@
 """Config and state management tools."""
 
 import os
+from pathlib import Path
+
+def home_dir():
+    """Return the home user directory"""
+    dir = Path.home()
+    return dir
 
 
 def xdg_dir():
     """Return the XDG_CONFIG_HOME or default."""
     if os.getenv("XDG_CONFIG_HOME"):
         return os.getenv("XDG_CONFIG_HOME")
-    return os.path.join(os.getenv("HOME"), ".config")
+    return os.path.join(home_dir(), ".config")
 
 
 def dfm_dir():

--- a/src/dfm/links.py
+++ b/src/dfm/links.py
@@ -6,6 +6,7 @@ import subprocess
 from shutil import rmtree
 
 from dfm.mappings import DEFAULT_MAPPINGS, Mapping
+from dfm.config import home_dir
 
 logger = logging.getLogger(__name__)
 
@@ -46,11 +47,14 @@ class LinkManager:
     def __init__(
         self,
         where,
-        target_dir=os.getenv("HOME"),
+        target_dir=None,
         mappings=None,
     ):
         self.where = where
-        self.target_dir = target_dir
+        if target_dir is None:
+            self.target_dir = home_dir()
+        else:
+            self.target_dir = target_dir
         if mappings is None:
             self.mappings = DEFAULT_MAPPINGS
         else:
@@ -61,7 +65,7 @@ class LinkManager:
         """Load link manager settings from config."""
         return cls(
             where=where,
-            target_dir=config.pop("target_dir", os.getenv("HOME")),
+            target_dir=config.pop("target_dir", home_dir()),
             mappings=Mapping.from_config(config),
         )
 
@@ -92,7 +96,7 @@ class LinkManager:
         # self.where does not always contain a trailing slash
         # This removes a leading slash from the front of dest if where
         # does not contain the trailing slash.
-        if dest.startswith("/"):
+        if dest.startswith(os.sep):
             dest = dest[1:]
 
         dest = os.path.join(self.target_dir, dest)

--- a/src/dfm/mappings.py
+++ b/src/dfm/mappings.py
@@ -51,7 +51,8 @@ class Mapping:
         if not self.skip:
             return False
 
-        # We aren't an OS-specific mapping and are a skip mapping so return should skip.
+        # We aren't an OS-specific mapping and are a skip mapping
+        # so return should skip.
         if not self.target_os:
             return True
 
@@ -59,8 +60,8 @@ class Mapping:
         if self.on_target_os():
             return True
 
-        # We are a skip mapping but we aren't on the target OS return False so the file
-        # is not skipped.
+        # We are a skip mapping but we aren't on the target OS
+        # return False so the file is not skipped.
         return False
 
     def replace(self, dest, target_dir):
@@ -73,13 +74,17 @@ class Mapping:
         elif self.dest:
             dest = self.dest
             if not dest.is_absolute():
-                dest = new_target_dir.joinpath(dest)
+                dest = self.target_dir.joinpath(dest)
         elif self.target_dir:
-            dest = default_dest
             # change the target dir if found in old dest
-            if dest.is_relative_to(old_target_dir):
-                rel_dest = dest.relative_to(old_target_dir)
+            # TODO: use PurePath.is_relative_to to check when (3.9) is old enough
+            # if default_dest.is_relative_to(old_target_dir):
+            try:
+                rel_dest = default_dest.relative_to(old_target_dir)
                 dest = self.target_dir.joinpath(rel_dest)
+            except ValueError:
+                # default_dest is not relative to old_target_dir
+                dest = default_dest
         return dest
 
     @classmethod

--- a/src/dfm/repo.py
+++ b/src/dfm/repo.py
@@ -5,6 +5,8 @@ import os
 import shlex
 import subprocess
 import sys
+import git
+from git.exc import InvalidGitRepositoryError,NoSuchPathError
 
 logger = logging.getLogger(__name__)
 
@@ -19,133 +21,205 @@ class DotfileRepo:  # pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,
-        where,
-        commit_msg,
+        path,
+        remote_url=None,
+        branch_name=None,
+        commit_msg=None,
         prompt_for_commit_message=False,
     ):
-        self.where = where
+        self.local_path = path
         self.commit_msg = commit_msg
         self.prompt_for_commit_message = prompt_for_commit_message
+        #
+        self._git_repo = None
+
+        self._init_branch_name = branch_name
+        self._remote_url = remote_url
+
+        try:
+            self._git_repo = git.Repo(self.local_path)
+            self._set_remote()
+            self._set_branch()
+        except (InvalidGitRepositoryError,NoSuchPathError):
+            # repo could not initialised (path does not exist, for instance)
+            #, will have to call initialise()
+            self._git_repo = None
+
+    def _set_remote(self):
+        self._remote_name = self._get_remote_name(remote_url=self._remote_url)
+        # create the remote if we have a url but no name
+        if self._remote_url is not None and self._remote_name is None:
+            self._remote_name = 'origin'
+        assert self._git_repo is not None
+        if self._remote_url is not None and self.get_remote() is None:
+            remote = self._git_repo.create_remote(self._remote_name, self._remote_url)
+            assert remote.exists()
+
+    def _set_branch(self):
+        self._branch_name = self._get_branch_name(remote_name=self._remote_name, branch_name=self._init_branch_name)
+        assert self._branch_name is not None
+        remote = self.get_remote()
+        branch = self.get_branch()
+        if branch is None:
+            if remote is not None:
+                remote_branch = remote.refs[self._branch_name]
+                branch = self._git_repo.create_head(self._branch_name, remote_branch)
+            else:
+                branch = self._git_repo.create_head(self._branch_name)
+        if remote is not None:
+            remote_branch = remote.refs[self._branch_name]
+            branch.set_tracking_branch(remote_branch)
+        assert self.get_branch() is not None
+
+
+
+    def is_initialised(self):
+        return self._git_repo is not None
+
+    def initialise(self):
+        """
+            Creates git repo
+        """
+        self._git_repo = git.Repo.init(self.local_path)
+        self._set_remote()
+        self.get_remote().fetch()
+        self._set_branch()
+        self.get_branch().checkout()
+
+    def get_remote(self):
+        has_remote = False
+        try:
+            remote = self._git_repo.remote(self._remote_name)
+            has_remote = remote.exists()
+        except ValueError:
+            has_remote = False
+        return remote if has_remote else None
+
+    def get_remote_url(self):
+        remote = self.get_remote()
+        if remote is not None:
+            url = next(remote.urls)
+            assert url is not None
+            return url
+        else:
+            return self._remote_url
+
+    def get_branch(self):
+        branch= None
+        if self._branch_name is not None:
+            try:
+                branch = self._git_repo.heads[self._branch_name]
+            except IndexError:
+                pass
+        return branch
+
+    def _get_remote_name(self, remote_url=None):
+        # take the first remote by default
+        # we get the name of the remote that we are interest about
+        has_remote = len(self._git_repo.remotes) > 0
+        remote_name = None
+        if remote_url is None:
+            # if no remote was explicitly given,
+            # we take the first one we found if it exists.
+            if has_remote:
+                remote_name = self._git_repo.remotes[0].name
+        else:
+            # find the name of the remote with the url
+            for remote in self._git_repo.remotes:
+                if remote.url == remote_url:
+                    remote_name = remote.name
+        return remote_name
+
+    def _get_branch_name(self, remote_name=None, branch_name=None):
+        active_branch_name = None
+        remote = self.get_remote()
+        has_remote = remote is not None
+        has_active_branch = False
+        try:
+            active_branch_name = self._git_repo.active_branch.name
+            has_active_branch = True
+        except TypeError:
+            has_active_branch = False
+        has_branch = len(self._git_repo.heads)
+        if branch_name is None:
+            # take the active branch name if it exists
+            if has_active_branch:
+                branch_name = active_branch_name
+            elif has_branch:
+                # take the first branch that exists
+                branch_name = self._git_repo.heads[0].name
+            elif has_remote and len(remote.repo.heads) > 0:
+                branch_name = remote.repo.heads[0].name
+            else:
+                # use a default one.
+                branch_name = 'main'
+        return branch_name
 
     @classmethod
-    def from_config(cls, where, config):
+    def from_config(cls, path, config: dict):
         """Load DotfileRepo settings from config."""
         return cls(
-            where=where,
+            path=path,
+            remote_url=config.get("repo"),
+            branch_name=config.get("branch"),
             commit_msg=config.pop("commit_msg", os.getenv("DFMgit_COMMIT_MSG")),
             prompt_for_commit_message=config.pop("prompt_for_commit_message", False),
         )
 
-    def init(self):
-        """Initialize the git repository."""
-        self.git("init")
 
-    def get_remote(self):  # pylint: disable=no-self-use
-        """Return the remote url for origin."""
-        try:
-            return subprocess.check_output(
-                ["git", "remote", "get-url", "origin"],
-                cwd=self.where,
-                stderr=subprocess.DEVNULL,
-            ).decode("utf-8")
-        except subprocess.CalledProcessError:
-            return None
+    def fetch(self, **kwargs):
+        # TODO: progress info
+        remote = self.get_remote()
+        assert remote is not None
+        remote.fetch(**kwargs)
 
-    def git(self, cmd, cwd=False, dry_run=False):
-        """
-        Run the git subcommand 'cmd' in this dotfile repo.
+    def pull(self, **kwargs):
+        # TODO: progress info
+        remote = self.get_remote()
+        assert remote is not None
+        remote.pull(**kwargs)
 
-        Sends all output and input to sys.stdout / sys.stdin.
-        cmd should be a string and will be split using shlex.split.
+    def push(self, **kwargs):
+        # TODO: progress info
+        remote = self.get_remote()
+        assert remote is not None
+        remote.push(**kwargs)
 
-        If cwd is set to None or a string then it will be passed to
-        Popen constructor as the cwd argument. Otherwise the cwd for
-        the process will be the location of the dotfile repo. Most
-        often you will not want to set this.
-        """
-        try:
-            if cwd is False:
-                cwd = self.where
-
-            args = ["git"] + shlex.split(cmd)
-
+    def query_commit_message(self, default_msg=None, dry_run=False):
+        commit_msg = self.commit_msg
+        if not commit_msg:
             if dry_run:
-                logger.info('Running: "%s" in %s', " ".join(args), cwd)
-                return
+                commit_msg = "noop"
+            elif default_msg:
+                commit_msg = default_msg
+            elif self.prompt_for_commit_message:
+                commit_msg = input("Commit message: ")
+            else:
+                commit_msg = "Files managed by DFM! https://github.com/chasinglogic/dfm"
+        return commit_msg
 
-            proc = subprocess.Popen(
-                args,
-                cwd=cwd,
-                stdin=sys.stdin,
-                stdout=sys.stdout,
-                stderr=sys.stderr,
-            )
-            proc.wait()
-        except OSError as os_err:
-            logger.error("problem runing git %s: %s", cmd, os_err)
-            sys.exit(1)
-
-    def _is_dirty(self):
-        """
-        Return the output of 'git status --porcelain'.
-
-        This is useful because in Python an empty string is False. The
-        --porcelain flag prints nothing if the git repo is not in a dirty state.
-        Therefore 'if self._is_dirty()' will behave as expected.
-        """
-        try:
-            return subprocess.check_output(
-                ["git", "status", "--porcelain"],
-                cwd=self.where,
-            )
-        # Something unexpected happened while running git so let's
-        # assume we can't run anymore git commands and skip trying to
-        # sync.
-        except OSError:
-            return False
 
     def sync(self, commit_msg="", dry_run=False):
         """Sync this profile with git."""
-        logger.info("Syncing: %s", self.where)
-        dirty = self._is_dirty()
-        if dirty:
-            self.git("--no-pager diff", dry_run=dry_run)
-
-            if not self.commit_msg and dry_run:
-                self.commit_msg = "noop"
-
-            elif not self.commit_msg and commit_msg:
-                self.commit_msg = commit_msg
-
-            elif not self.commit_msg and self.prompt_for_commit_message:
-                self.commit_msg = input("Commit message: ")
-
-            elif not self.commit_msg:
-                self.commit_msg = (
-                    "Files managed by DFM! https://github.com/chasinglogic/dfm"
-                )
-
-            self.git("add --all", dry_run=dry_run)
-            self.git(
-                'commit -m "{}"'.format(self.commit_msg),
-                dry_run=dry_run,
-            )
-
-        if self._has_origin():
-            self.git(
-                "pull --rebase origin master",
-                dry_run=dry_run,
-            )
-            if dirty:
-                self.git(
-                    "push origin master",
-                    dry_run=dry_run,
-                )
-
-    def _has_origin(self):
-        """Return a boolean indicating if a remote named origin is available."""
-        try:
-            output = subprocess.check_output(["git", "remote", "-v"], cwd=self.where)
-            return b"origin" in output
-        except OSError:
-            return False
+        logger.info("Syncing: %s", self.local_path)
+        remote = self.get_remote()
+        if remote is None:
+            try:
+                head = self._git_repo.active_branch
+            except TypeError:
+                # TODO: HEAD is detached, handle how?
+                # Probably not like this.
+                self.get_branch().checkout()
+        else:
+            self.fetch()
+        if self._git_repo.is_dirty(untracked_files=True):
+            # repo_index.diff(
+            commit_msg = self.query_commit_message(commit_msg, dry_run=dry_run)
+            repo_index = self._git_repo.index
+            if not dry_run:
+                repo_index.add('./')
+                commit = repo_index.commit(commit_msg)
+                # logger.info(repo_commit.diff())
+        if remote is not None:
+            self.pull(rebase=True, dry_run=dry_run)
+            self.push(dry_run=dry_run)

--- a/tests/test_linking.py
+++ b/tests/test_linking.py
@@ -5,7 +5,7 @@ import platform
 from operator import itemgetter
 from tempfile import TemporaryDirectory
 
-from dfm.config import xdg_dir
+from dfm.config import home_dir, xdg_dir
 from dfm.links import LinkManager
 from dfm.profile import Profile
 
@@ -52,33 +52,33 @@ mappings:
     expected_links = [
         {
             "src": os.path.join(directory, ".vimrc"),
-            "dst": os.path.join(os.getenv("HOME"), ".vimrc"),
+            "dst": os.path.join(home_dir(), ".vimrc"),
         },
         {
             "src": os.path.join(directory, ".bashrc"),
-            "dst": os.path.join(os.getenv("HOME"), ".bashrc"),
+            "dst": os.path.join(home_dir(), ".bashrc"),
         },
         {
             "src": os.path.join(directory, ".emacs"),
-            "dst": os.path.join(os.getenv("HOME"), ".emacs"),
+            "dst": os.path.join(home_dir(), ".emacs"),
         },
         {
             "src": os.path.join(directory, ".ggitignore"),
-            "dst": os.path.join(os.getenv("HOME"), ".gitignore"),
+            "dst": os.path.join(home_dir(), ".gitignore"),
         },
         {
             "src": os.path.join(directory, ".emacs.d", "init.el"),
-            "dst": os.path.join(os.getenv("HOME"), ".emacs.d", "init.el"),
+            "dst": os.path.join(home_dir(), ".emacs.d", "init.el"),
         },
         {
             "src": os.path.join(directory, ".map_to_os_name"),
             "dst": os.path.join(
-                os.getenv("HOME"), ".{name}".format(name=platform.system())
+                home_dir(), ".{name}".format(name=platform.system())
             ),
         },
         {
             "src": os.path.join(directory, ".skip_on_another_os"),
-            "dst": os.path.join(os.getenv("HOME"), ".skip_on_another_os"),
+            "dst": os.path.join(home_dir(), ".skip_on_another_os"),
         },
     ]
 


### PR DESCRIPTION
Hi!
Thanks for dfm, I've been using to set-up a few GNU/Linux machines and I'm liking it so far. 

### Rationale

So I've been wanting to include some third-party repos into my profile
(mainly plug-in managers such as [vim-plug](https://github.com/junegunn/vim-plug)) and I've been adding them as modules.
Since installing them amounts to simply copying a few files,
I found it useful to only link _some_ files in, and skip the rest.
Using this change, one can do the above like so:

```yml
# .dfm.yml for my profile
modules:
  - repo: my_repo
  mappings:
    # my catch-all pattern
    - match: '.*'
      skip: true
   # only my_file will be linked
    - match: my_file
       target_dit: ~/.my_config_dir
```


I'm not convinced by the picking of the last one instead of the first,
but it matches previous behaviour more closely when there was no `skip` or `link_as_dir` option in the module.

###  Before

- `generate_link` would to skip all mappings`
if a single `skip`option was found for the module,
- it would return immediately if `link_as_dir` was found,
- otherwise, it would pick the last matching mapping.

### Now

- `generate_link` always picks the last of matching mappings.

